### PR TITLE
Fix PHP 8.2 deprecation warning

### DIFF
--- a/lib/Request.php
+++ b/lib/Request.php
@@ -32,6 +32,11 @@ class Request extends Message implements RequestInterface {
     protected $url;
 
     /**
+     * @var string
+     */
+    private $absoluteUrl;
+
+    /**
      * Creates the request object
      *
      * @param string $method


### PR DESCRIPTION
## What / why
Fix the following deprecation warning:

`Deprecated: Creation of dynamic property Sabre\HTTP\Request::$absoluteUrl is deprecated in sabre/http/lib/Request.php on line 127`

See https://php.watch/versions/8.2/dynamic-properties-deprecated


This has been fixed in the official version (https://github.com/sabre-io/http/commit/7d91cdb1417eddbfa5e433b298345ad67d4f9266, https://github.com/sabre-io/http/commit/4dace4c60cf12b8e27ebc238659b70816946e907) but we're way behind. 

ping @bigcommerce/php