### PR TITLE
chore(platform): PHPMNT-177 Support PHP 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,14 +5,14 @@
     "homepage" : "https://github.com/fruux/sabre-http",
     "license" : "BSD-3-Clause",
     "require" : {
-        "php"          : ">=7.0",
+        "php"          : ">=8.1",
         "ext-mbstring" : "*",
-        "sabre/event"  : "^4.0",
+        "sabre/event"  : "^5.0",
         "sabre/uri"    : "^2.0"
     },
     "require-dev" : {
-        "phpunit/phpunit" : ">=5.6.0",
-        "sabre/cs" : "~1.0.0"
+        "friendsofphp/php-cs-fixer": "~3.66",
+        "phpunit/phpunit" : "~9.0"
     },
     "suggest" : {
         "ext-curl" : " to make http requests with the Client class"

--- a/lib/Auth/AbstractAuth.php
+++ b/lib/Auth/AbstractAuth.php
@@ -40,7 +40,7 @@ abstract class AbstractAuth {
     /**
      * Creates the object
      */
-    function __construct(string $realm = 'SabreTooth', RequestInterface $request, ResponseInterface $response) {
+    function __construct(?string $realm, RequestInterface $request, ResponseInterface $response) {
 
         $this->realm = $realm;
         $this->request = $request;

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -170,7 +170,7 @@ class Client extends EventEmitter {
      *
      * @return void
      */
-    function sendAsync(RequestInterface $request, callable $success = null, callable $error = null) {
+    function sendAsync(RequestInterface $request, ?callable $success = null, ?callable $error = null) {
 
         $this->emit('beforeRequest', [$request]);
         $this->sendAsyncInternal($request, $success, $error);

--- a/lib/Response.php
+++ b/lib/Response.php
@@ -98,10 +98,10 @@ class Response extends Message implements ResponseInterface {
      * Creates the response object
      *
      * @param string|int $status
-     * @param array $headers
+     * @param ?array $headers
      * @param resource $body
      */
-    function __construct($status = null, array $headers = null, $body = null) {
+    function __construct($status = null, ?array $headers = null, $body = null) {
 
         if (!is_null($status)) $this->setStatus($status);
         if (!is_null($headers)) $this->setHeaders($headers);
@@ -145,7 +145,7 @@ class Response extends Message implements ResponseInterface {
      */
     function setStatus($status) {
 
-        if (ctype_digit($status) || is_int($status)) {
+        if (is_numeric($status) || is_int($status)) {
 
             $statusCode = $status;
             $statusText = isset(self::$statusCodes[$status]) ? self::$statusCodes[$status] : 'Unknown';

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -427,7 +427,7 @@ function decodePathSegment(string $path) : string {
     switch ($encoding) {
 
         case 'ISO-8859-1' :
-            $path = utf8_encode($path);
+            $path = mb_convert_encoding($path, 'UTF-8', 'ISO-8859-1');
 
     }
 

--- a/tests/HTTP/Auth/AWSTest.php
+++ b/tests/HTTP/Auth/AWSTest.php
@@ -2,10 +2,11 @@
 
 namespace Sabre\HTTP\Auth;
 
+use PHPUnit\Framework\TestCase;
 use Sabre\HTTP\Request;
 use Sabre\HTTP\Response;
 
-class AWSTest extends \PHPUnit_Framework_TestCase {
+class AWSTest extends TestCase {
 
     /**
      * @var Sabre\HTTP\Response
@@ -24,7 +25,7 @@ class AWSTest extends \PHPUnit_Framework_TestCase {
 
     const REALM = 'SabreDAV unittest';
 
-    function setUp() {
+    function setUp(): void {
 
         $this->response = new Response();
         $this->request = new Request('GET', '/');

--- a/tests/HTTP/Auth/BasicTest.php
+++ b/tests/HTTP/Auth/BasicTest.php
@@ -2,10 +2,11 @@
 
 namespace Sabre\HTTP\Auth;
 
+use PHPUnit\Framework\TestCase;
 use Sabre\HTTP\Request;
 use Sabre\HTTP\Response;
 
-class BasicTest extends \PHPUnit_Framework_TestCase {
+class BasicTest extends TestCase {
 
     function testGetCredentials() {
 

--- a/tests/HTTP/Auth/BearerTest.php
+++ b/tests/HTTP/Auth/BearerTest.php
@@ -2,10 +2,11 @@
 
 namespace Sabre\HTTP\Auth;
 
+use PHPUnit\Framework\TestCase;
 use Sabre\HTTP\Request;
 use Sabre\HTTP\Response;
 
-class BearerTest extends \PHPUnit_Framework_TestCase {
+class BearerTest extends TestCase {
 
     function testGetToken() {
 

--- a/tests/HTTP/Auth/DigestTest.php
+++ b/tests/HTTP/Auth/DigestTest.php
@@ -2,10 +2,11 @@
 
 namespace Sabre\HTTP\Auth;
 
+use PHPUnit\Framework\TestCase;
 use Sabre\HTTP\Request;
 use Sabre\HTTP\Response;
 
-class DigestTest extends \PHPUnit_Framework_TestCase {
+class DigestTest extends TestCase {
 
     /**
      * @var Sabre\HTTP\Response
@@ -26,7 +27,7 @@ class DigestTest extends \PHPUnit_Framework_TestCase {
 
     const REALM = 'SabreDAV unittest';
 
-    function setUp() {
+    function setUp(): void {
 
         $this->response = new Response();
         $this->request = new Request('GET', '/');
@@ -95,7 +96,7 @@ class DigestTest extends \PHPUnit_Framework_TestCase {
     function testInvalidDigest2() {
 
         $this->request->setMethod('GET');
-        $this->request->setHeader('Authorization', 'basic blablabla');
+        $this->request->setHeader('Authorization', 'Basic dXNlcjpwYXNzd29yZA');
 
         $this->auth->init();
         $this->assertFalse($this->auth->validateA1(md5('user:realm:password')));

--- a/tests/HTTP/ClientTest.php
+++ b/tests/HTTP/ClientTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\HTTP;
 
-class ClientTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class ClientTest extends TestCase {
 
     function testCreateCurlSettingsArrayGET() {
 

--- a/tests/HTTP/FunctionsTest.php
+++ b/tests/HTTP/FunctionsTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\HTTP;
 
-class FunctionsTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class FunctionsTest extends TestCase {
 
     /**
      * @dataProvider getHeaderValuesData

--- a/tests/HTTP/MessageDecoratorTest.php
+++ b/tests/HTTP/MessageDecoratorTest.php
@@ -2,12 +2,14 @@
 
 namespace Sabre\HTTP;
 
-class MessageDecoratorTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class MessageDecoratorTest extends TestCase {
 
     protected $inner;
     protected $outer;
 
-    function setUp() {
+    function setUp(): void {
 
         $this->inner = new Request('GET', '/');
         $this->outer = new RequestDecorator($this->inner);

--- a/tests/HTTP/MessageTest.php
+++ b/tests/HTTP/MessageTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\HTTP;
 
-class MessageTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class MessageTest extends TestCase {
 
     function testConstruct() {
 

--- a/tests/HTTP/NegotiateTest.php
+++ b/tests/HTTP/NegotiateTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\HTTP;
 
-class NegotiateTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class NegotiateTest extends TestCase {
 
     /**
      * @dataProvider negotiateData

--- a/tests/HTTP/RequestDecoratorTest.php
+++ b/tests/HTTP/RequestDecoratorTest.php
@@ -2,12 +2,14 @@
 
 namespace Sabre\HTTP;
 
-class RequestDecoratorTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class RequestDecoratorTest extends TestCase {
 
     protected $inner;
     protected $outer;
 
-    function setUp() {
+    function setUp(): void {
 
         $this->inner = new Request('GET', '/');
         $this->outer = new RequestDecorator($this->inner);

--- a/tests/HTTP/RequestTest.php
+++ b/tests/HTTP/RequestTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\HTTP;
 
-class RequestTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class RequestTest extends TestCase {
 
     function testConstruct() {
 
@@ -108,10 +110,8 @@ class RequestTest extends \PHPUnit_Framework_TestCase {
 
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     function testGetPathOutsideBaseUrl() {
+        $this->expectException(\LogicException::class);
 
         $request = new Request('GET', '/bar/');
         $request->setBaseUrl('/foo/');

--- a/tests/HTTP/ResponseDecoratorTest.php
+++ b/tests/HTTP/ResponseDecoratorTest.php
@@ -2,12 +2,14 @@
 
 namespace Sabre\HTTP;
 
-class ResponseDecoratorTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class ResponseDecoratorTest extends TestCase {
 
     protected $inner;
     protected $outer;
 
-    function setUp() {
+    function setUp(): void {
 
         $this->inner = new Response();
         $this->outer = new ResponseDecorator($this->inner);

--- a/tests/HTTP/ResponseTest.php
+++ b/tests/HTTP/ResponseTest.php
@@ -2,7 +2,10 @@
 
 namespace Sabre\HTTP;
 
-class ResponseTest extends \PHPUnit_Framework_TestCase {
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class ResponseTest extends TestCase {
 
     function testConstruct() {
 
@@ -21,10 +24,9 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     function testInvalidStatus() {
+
+        $this->expectException(InvalidArgumentException::class);
 
         $response = new Response(1000);
 

--- a/tests/HTTP/SapiTest.php
+++ b/tests/HTTP/SapiTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\HTTP;
 
-class SapiTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class SapiTest extends TestCase {
 
     function testConstructFromServerArray() {
 

--- a/tests/HTTP/URLUtilTest.php
+++ b/tests/HTTP/URLUtilTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\HTTP;
 
-class URLUtilTest extends \PHPUnit_Framework_TestCase{
+use PHPUnit\Framework\TestCase;
+
+class URLUtilTest extends TestCase {
 
     function testEncodePath() {
 


### PR DESCRIPTION
## What/Why
Support PHP 8.4
- Loosen dependency on sabre/event to fix warnings - see [changelog](https://github.com/sabre-io/event/releases/tag/5.0.0)
- Replace sable/cs with friendsofphp/php-cs-fixer since the former is abandoned
- Upgrade PHPUnit to v9
- Fix deprecation warnings around implicitly nullable arguments, ctype_digit() and array offset issues (check before accessing)